### PR TITLE
Fix only one update being listed per title

### DIFF
--- a/index.php
+++ b/index.php
@@ -84,7 +84,7 @@ function matchTitleIds($files)
                 $baseTitleId = substr_replace($titleId, "000", -3);
                 // add Update only if the Base TitleId for it exists
                 if ($titles[$baseTitleId]) {
-                    $titles[$baseTitleId]['updates'][$titleId] = array(
+                    $titles[$baseTitleId]['updates'][$version] = array(
                         "path" => $file,
                         "version" => $version
                     );


### PR DESCRIPTION
I noticed that only one update version is listed per title. Changing it to use `version` instead of `titleId` for the key in the `updates` object fixes this.