### PR TITLE
Fix PFS0 file table name offset and size

### DIFF
--- a/lib/PFS0.php
+++ b/lib/PFS0.php
@@ -23,9 +23,9 @@ class PFS0
         $this->fileBodyOffset = $this->stringTableOffset + $this->stringTableSize;
 		$this->filesList = [];
         for ($i = 0; $i < $this->numFiles; $i++) {
-            $dataOffset = unpack("P", substr($this->data, 0x10 + (0x20 * $i), 0x08))[1];
-            $dataSize = unpack("P", substr($this->data, 0x18 + (0x20 * $i), 0x08))[1];
-            $stringOffset = unpack("V", substr($this->data, 0x1c + (0x20 * $i), 0x04))[1];
+            $dataOffset = unpack("P", substr($this->data, 0x10 + (0x18 * $i), 0x08))[1];
+            $dataSize = unpack("P", substr($this->data, 0x18 + (0x18 * $i), 0x08))[1];
+            $stringOffset = unpack("V", substr($this->data, 0x20 + (0x18 * $i), 0x04))[1];
             $filename = "";
             $n = 0;
             while (true && $this->stringTableOffset + $stringOffset + $n < $this->dataSize-1) {


### PR DESCRIPTION
Entry size is 0x18 String offset is at +0x10 from the start of the entry

This was leading to NSZ files where the first entry in the string table was not a .ncz being wrongly detected as a NSP file due to filesList being filled with garbage data.