### PR TITLE
Add PHP linting VSCode tasks and GitHub workflow

### DIFF
--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -22,8 +22,6 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
-        with:
-          path: "nspindexer"
 
       - name: Install PHP CodeSniffer and requirements
         run: |
@@ -39,9 +37,9 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          cd  $GITHUB_WORKSPACE/nspindexer && \
+          cd  $GITHUB_WORKSPACE && \
           if [ "${{github.event_name}}" == 'pull_request' ]; then
-              phpcs --report=json --standard=PSR12 \
+              phpcs --report=json --standard=PSR12 . \
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \
                 -name="phpcs" \
@@ -49,7 +47,7 @@ jobs:
                 -filter-mode="nofilter" \
                 -fail-on-error
           else
-              phpcs --report=checkstyle --standard=PSR12 \
+              phpcs --report=checkstyle --standard=PSR12 . \
               | reviewdog -f="checkstyle" \
                 -name="phpcs" \
                 -reporter="github-check" \

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -38,7 +38,7 @@ jobs:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
           if [ "${{github.event_name}}" == 'pull_request' ]; then
-              phpcs --report=json --standard=PSR12 \
+              phpcs --report=json --standard=PSR12 . \
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \
                 -name="phpcs" \
@@ -46,7 +46,7 @@ jobs:
                 -filter-mode="nofilter" \
                 -fail-on-error
           else
-              phpcs --report=checkstyle --standard=PSR12 \
+              phpcs --report=checkstyle --standard=PSR12 . \
               | reviewdog -f="checkstyle" \
                 -name="phpcs" \
                 -reporter="github-check" \

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -23,9 +23,9 @@ jobs:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      - name: Install PHP CodeSniffer
+      - name: Install PHP CodeSniffer and requirements
         run: |
-          apk add --no-cache php81-pear \
+          apk add --no-cache bash php81-pear \
           && pear install PHP_CodeSniffer
 
       - name: Install Reviewdog

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -37,7 +37,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          if [${github.event_name} == "pull_request"]; then
+          if [${{github.event_name}} == "pull_request"]; then
               phpcs --report=json --standard=PSR12 \
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -15,7 +15,7 @@ on:  # yamllint disable-line rule:truthy
       - '**/Dockerfile.*'
 
 jobs:
-  markdownlint:
+  phpcs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repo
@@ -29,7 +29,7 @@ jobs:
             echo "REVIEWDOG_REPORTER=github-pr-review" >> $GITHUB_ENV
           fi
 
-      - name: Lint Dockerfile
+      - name: Run PHP CodeSniffer
         uses: shirobrak/action-phpcs@v1.5.0
         with:
           reporter: ${{ env.REVIEWDOG_REPORTER }}

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -49,7 +49,7 @@ jobs:
               phpcs --report=checkstyle --standard=PSR12 \
               | reviewdog -f="checkstyle" \
                 -name="phpcs" \
-                -reporter="github-pr-check" \
+                -reporter="github-check" \
                 -filter-mode="nofilter" \
                 -fail-on-error
           fi

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -19,16 +19,6 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: php:8.1.9-alpine
-    
-
-                "docker run --rm -it",
-                "-v ${workspaceFolder}:/workspace",
-                "php:8.1.9-alpine",
-                "/bin/sh -c",
-                "'apk add --no-cache php81-pear",
-                "&& pear install PHP_CodeSniffer",
-                "&& phpcs --standard=${config:phpcs_standard} --report=emacs /workspace'"
-
     steps:
       - name: Check out repo
         uses: actions/checkout@v3

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -17,22 +17,49 @@ on:  # yamllint disable-line rule:truthy
 jobs:
   phpcs:
     runs-on: ubuntu-latest
+    container:
+      image: php:8.1.9-alpine
+    
+
+                "docker run --rm -it",
+                "-v ${workspaceFolder}:/workspace",
+                "php:8.1.9-alpine",
+                "/bin/sh -c",
+                "'apk add --no-cache php81-pear",
+                "&& pear install PHP_CodeSniffer",
+                "&& phpcs --standard=${config:phpcs_standard} --report=emacs /workspace'"
+
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
 
-      - name: Set reviewdog reporter type
+      - name: Install PHP CodeSniffer
         run: |
-          if [ ${{ github.event_name }} != "pull_request" ]; then
-            echo "REVIEWDOG_REPORTER=local" >> $GITHUB_ENV
-          else
-            echo "REVIEWDOG_REPORTER=github-pr-review" >> $GITHUB_ENV
-          fi
+          apk add --no-cache php81-pear \
+          && pear install PHP_CodeSniffer
+
+      - name: Install Reviewdog
+        uses: reviewdog/action-setup@v1
+        with:
+          reviewdog_version: latest
 
       - name: Run PHP CodeSniffer
-        uses: shirobrak/action-phpcs@v1.5.0
-        with:
-          reporter: ${{ env.REVIEWDOG_REPORTER }}
-          level: info
-          filter_mode: nofilter
-          fail_on_error: true
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          if [${github.event_name} == "pull_request"]; then
+              phpcs --report=json --standard=PSR12 \
+              | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
+              | reviewdog -efm="%f:%l:%c:%m" \
+                -name="phpcs" \
+                -reporter="github-pr-review" \
+                -filter-mode="none" \
+                -fail-on-error="true"
+          else
+              phpcs --report=checkstyle --standard=PSR12 \
+              | reviewdog -f="checkstyle" \
+                -name="phpcs" \
+                -reporter="github-pr-review" \
+                -filter-mode="none" \
+                -fail-on-error="true"
+          fi

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -42,14 +42,14 @@ jobs:
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \
                 -name="phpcs" \
-                -reporter="github-pr-check" \
+                -reporter="github-pr-review" \
                 -filter-mode="nofilter" \
                 -fail-on-error
           else
               phpcs --report=checkstyle --standard=PSR12 \
               | reviewdog -f="checkstyle" \
                 -name="phpcs" \
-                -reporter="github-pr-review" \
+                -reporter="github-pr-check" \
                 -filter-mode="nofilter" \
                 -fail-on-error
           fi

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -37,7 +37,7 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          if ["${{github.event_name}}" == "pull_request"]; then
+          if [ "${{github.event_name}}" == 'pull_request' ]; then
               phpcs --report=json --standard=PSR12 \
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Check out repo
         uses: actions/checkout@v3
+        with:
+          path: "nspindexer"
 
       - name: Install PHP CodeSniffer and requirements
         run: |
@@ -37,8 +39,9 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
+          cd  $GITHUB_WORKSPACE/nspindexer && \
           if [ "${{github.event_name}}" == 'pull_request' ]; then
-              phpcs --report=json --standard=PSR12 . \
+              phpcs --report=json --standard=PSR12 \
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \
                 -name="phpcs" \
@@ -46,7 +49,7 @@ jobs:
                 -filter-mode="nofilter" \
                 -fail-on-error
           else
-              phpcs --report=checkstyle --standard=PSR12 . \
+              phpcs --report=checkstyle --standard=PSR12 \
               | reviewdog -f="checkstyle" \
                 -name="phpcs" \
                 -reporter="github-check" \

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -37,19 +37,19 @@ jobs:
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
         run: |
-          if [${{github.event_name}} == "pull_request"]; then
+          if ["${{github.event_name}}" == "pull_request"]; then
               phpcs --report=json --standard=PSR12 \
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \
                 -name="phpcs" \
                 -reporter="github-pr-review" \
-                -filter-mode="none" \
-                -fail-on-error="true"
+                -filter-mode="nofilter" \
+                -fail-on-error
           else
               phpcs --report=checkstyle --standard=PSR12 \
               | reviewdog -f="checkstyle" \
                 -name="phpcs" \
                 -reporter="github-pr-review" \
-                -filter-mode="none" \
-                -fail-on-error="true"
+                -filter-mode="nofilter" \
+                -fail-on-error
           fi

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -42,7 +42,7 @@ jobs:
               | jq -r ' .files | to_entries[] | .key as $path | .value.messages[] as $msg | "\($path):\($msg.line):\($msg.column):`\($msg.source)`<br>\($msg.message)" ' \
               | reviewdog -efm="%f:%l:%c:%m" \
                 -name="phpcs" \
-                -reporter="github-pr-review" \
+                -reporter="github-pr-check" \
                 -filter-mode="nofilter" \
                 -fail-on-error
           else

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -20,18 +20,19 @@ jobs:
     container:
       image: php:8.1.9-alpine
     steps:
-      - name: Check out repo
-        uses: actions/checkout@v3
 
       - name: Install PHP CodeSniffer and requirements
         run: |
-          apk add --no-cache bash php81-pear \
+          apk add --no-cache bash git php81-pear \
           && pear install PHP_CodeSniffer
 
       - name: Install Reviewdog
         uses: reviewdog/action-setup@v1
         with:
           reviewdog_version: latest
+
+      - name: Check out repo
+        uses: actions/checkout@v3
 
       - name: Run PHP CodeSniffer
         env:

--- a/.github/workflows/lint-php.yaml
+++ b/.github/workflows/lint-php.yaml
@@ -1,0 +1,38 @@
+---
+name: Lint codebase
+
+on:  # yamllint disable-line rule:truthy
+  # Allow manual runs.
+  workflow_dispatch:
+  # Also run on updates to this repo.
+  push:
+    paths-ignore:
+      - '**/*.md'
+      - '**/Dockerfile.*'
+  pull_request:
+    paths-ignore:
+      - '**/*.md'
+      - '**/Dockerfile.*'
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@v3
+
+      - name: Set reviewdog reporter type
+        run: |
+          if [ ${{ github.event_name }} != "pull_request" ]; then
+            echo "REVIEWDOG_REPORTER=local" >> $GITHUB_ENV
+          else
+            echo "REVIEWDOG_REPORTER=github-pr-review" >> $GITHUB_ENV
+          fi
+
+      - name: Lint Dockerfile
+        uses: shirobrak/action-phpcs@v1.5.0
+        with:
+          reporter: ${{ env.REVIEWDOG_REPORTER }}
+          level: info
+          filter_mode: nofilter
+          fail_on_error: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+    "triggerTaskOnSave.tasks": {
+        "Lint PHP": ["*.php", "*.html", "*.js", "*.css"],
+        // Or, for a harsher variant:
+        // "Auto-fix PHP": ["*.php", "*.html", "*.js", "*.css"],
+    },
+    "triggerTaskOnSave.showNotifications": true,
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,5 @@
         // "Auto-fix PHP": ["*.php", "*.html", "*.js", "*.css"],
     },
     "triggerTaskOnSave.showNotifications": true,
+    "phpcs_standard": "PSR12",
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,15 @@
        {
             "label": "Lint PHP",
             "type": "shell",
-            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcs --standard=PSR12 --report=emacs /workspace'",
+            "command": [
+                "docker run --rm -it",
+                "-v ${workspaceFolder}:/workspace",
+                "php:8.1.9-alpine",
+                "/bin/sh -c",
+                "'apk add --no-cache php81-pear",
+                "&& pear install PHP_CodeSniffer",
+                "&& phpcs --standard=PSR12 --report=emacs /workspace'"
+            ],
             "group": {
                 "kind": "test",
             },
@@ -28,7 +36,16 @@
         {
             "label": "Auto-fix PHP",
             "type": "shell",
-            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcbf --standard=PSR12 /workspace'",
+            "command": [
+                "docker run --rm -it",
+                "-v ${workspaceFolder}:/workspace",
+                "php:8.1.9-alpine",
+                "/bin/sh -c",
+                "'apk add --no-cache php81-pear",
+                "&& pear install PHP_CodeSniffer",
+                "&& phpcbf --standard=PSR12 /workspace",
+                "|| phpcs --standard=PSR12 --report=emacs /workspace'"
+            ],
             "group": {
                 "kind": "test",
             },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -13,7 +13,7 @@
                 "/bin/sh -c",
                 "'apk add --no-cache php81-pear",
                 "&& pear install PHP_CodeSniffer",
-                "&& phpcs --standard=PSR12 --report=emacs /workspace'"
+                "&& phpcs --standard=${config:phpcs_standard} --report=emacs /workspace'"
             ],
             "group": {
                 "kind": "test",
@@ -43,8 +43,8 @@
                 "/bin/sh -c",
                 "'apk add --no-cache php81-pear",
                 "&& pear install PHP_CodeSniffer",
-                "&& phpcbf --standard=PSR12 /workspace",
-                "|| phpcs --standard=PSR12 --report=emacs /workspace'"
+                "&& phpcbf --standard=${config:phpcs_standard} /workspace",
+                "|| phpcs --standard=${config:phpcs_standard} --report=emacs /workspace'"
             ],
             "group": {
                 "kind": "test",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -6,7 +6,7 @@
        {
             "label": "Lint PHP",
             "type": "shell",
-            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcs --standard=PSR2 --report=emacs /workspace'",
+            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcs --standard=PSR12 --report=emacs /workspace'",
             "group": {
                 "kind": "test",
             },
@@ -28,7 +28,7 @@
         {
             "label": "Auto-fix PHP",
             "type": "shell",
-            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcbf --standard=PSR2 /workspace'",
+            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcbf --standard=PSR12 /workspace'",
             "group": {
                 "kind": "test",
             },

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,51 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+       {
+            "label": "Lint PHP",
+            "type": "shell",
+            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcs --standard=PSR2 --report=emacs /workspace'",
+            "group": {
+                "kind": "test",
+            },
+            "problemMatcher": {
+                "owner": "php",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": [
+                    {
+                    "regexp": "^/workspace/(.*):(\\d+):(\\d+):\\s+(.*) - (.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                    }
+                ]
+            },
+        },
+        {
+            "label": "Auto-fix PHP",
+            "type": "shell",
+            "command": "docker run --rm -it -v ${PWD}:/workspace php:8.1.9-alpine /bin/sh -c 'apk add --no-cache php81-pear && pear install PHP_CodeSniffer-3.6.1 && phpcbf --standard=PSR2 /workspace'",
+            "group": {
+                "kind": "test",
+            },
+            "problemMatcher": {
+                "owner": "php",
+                "fileLocation": ["relative", "${workspaceFolder}"],
+                "pattern": [
+                    {
+                    "regexp": "^/workspace/(.*):(\\d+):(\\d+):\\s+(.*) - (.*)$",
+                    "file": 1,
+                    "line": 2,
+                    "column": 3,
+                    "severity": 4,
+                    "message": 5
+                    }
+                ]
+            },
+        },
+    ]
+}


### PR DESCRIPTION
This adds a GitHub workflow to check the main codebase for style errors according to the [PSR-12 PHP code standard](https://www.php-fig.org/psr/psr-12/), as well as a pair of Visual Studio Code test tasks to check for errors within VSCode and to automatically fix errors if possible.
